### PR TITLE
feat: add automated release workflow with Homebrew support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,80 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build macOS binary
+        run: bun build src/index.ts --compile --outfile whap --target=bun-darwin-x64
+
+      - name: Build Linux binary
+        run: bun build src/index.ts --compile --outfile whap-linux --target=bun-linux-x64
+
+      - name: Create macOS tarball
+        run: tar -czf whap-darwin-x64.tar.gz whap
+
+      - name: Create Linux tarball
+        run: tar -czf whap-linux-x64.tar.gz whap-linux
+
+      - name: Create Release and Upload Assets
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ github.ref_name }}
+          name: Release ${{ github.ref_name }}
+          generate_release_notes: true
+          files: |
+            whap-darwin-x64.tar.gz
+            whap-linux-x64.tar.gz
+
+      - name: Calculate SHA256 checksum
+        id: checksum
+        run: |
+          SHA256=$(sha256sum whap-darwin-x64.tar.gz | cut -d' ' -f1)
+          echo "sha256=$SHA256" >> $GITHUB_OUTPUT
+
+      - name: Extract version from tag
+        id: version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Update Homebrew formula
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          SHA256="${{ steps.checksum.outputs.sha256 }}"
+          
+          # Update version, URL, and SHA256 in Formula/whap.rb
+          sed -i "s/version \".*\"/version \"$VERSION\"/" Formula/whap.rb
+          sed -i "s|url \".*\"|url \"https://github.com/fdarian/whap/releases/download/v$VERSION/whap-darwin-x64.tar.gz\"|" Formula/whap.rb
+          sed -i "s/sha256 \".*\"/sha256 \"$SHA256\"/" Formula/whap.rb
+
+      - name: Configure git
+        run: |
+          git config --local user.email "action@github.com"
+          git config --local user.name "GitHub Action"
+
+      - name: Commit and push formula update
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          git add Formula/whap.rb
+          git commit -m "chore: update Homebrew formula for version $VERSION"
+          git push origin HEAD:main

--- a/Formula/whap.rb
+++ b/Formula/whap.rb
@@ -1,0 +1,15 @@
+class Whap < Formula
+  desc "CLI and mock server for testing WhatsApp integration"
+  homepage "https://github.com/fdarian/whap"
+  version "0.1.0"
+  url "https://github.com/fdarian/whap/releases/download/v0.1.0/whap-darwin-x64.tar.gz"
+  sha256 "placeholder_sha256_will_be_updated_by_ci"
+
+  def install
+    bin.install "whap"
+  end
+
+  test do
+    system "#{bin}/whap", "--version"
+  end
+end

--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
 	"name": "whap",
+	"version": "0.1.0",
 	"description": "CLI and mock server for testing WhatsApp integration",
 	"type": "module",
 	"bin": {


### PR DESCRIPTION
## Summary
This PR adds a comprehensive automated release workflow that streamlines the distribution process for the Whap CLI tool.

## Changes Made
- **GitHub Actions Workflow** (`.github/workflows/release.yml`): Automated release pipeline that triggers on version tags
- **Homebrew Formula** (`Formula/whap.rb`): Package definition for Homebrew distribution
- **Package Version** (`package.json`): Added initial version "0.1.0"

## Features
- **Automated Builds**: Creates binaries for both macOS and Linux platforms using Bun's compile feature
- **GitHub Releases**: Automatically creates releases with auto-generated release notes
- **Asset Distribution**: Uploads platform-specific tarballs to GitHub releases
- **Homebrew Integration**: Automatically updates the Homebrew formula with new versions and checksums
- **Simple Installation**: Users can install via `brew tap fdarian/whap && brew install whap`

## Workflow Details
- Triggers on version tags matching pattern `v*` (e.g., `v0.1.0`, `v1.2.3`)
- Builds cross-platform binaries using Bun's compile target system
- Calculates SHA256 checksums for security verification
- Updates Homebrew formula with new version, download URL, and checksum
- Commits formula changes back to the main branch

## Test Plan
- [ ] Create a test tag to verify the workflow runs correctly
- [ ] Verify binary compilation for both platforms
- [ ] Test Homebrew formula installation process
- [ ] Confirm GitHub release creation with proper assets

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added prebuilt binaries for macOS and Linux available via Releases.
  - Enabled Homebrew installation on macOS with a formula and basic install verification.
- Chores
  - Introduced an automated release workflow that publishes versioned builds and updates Homebrew metadata.
  - Set initial project version to 0.1.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->