### PR TITLE
Fix CLI not closing immediately after displaying help

### DIFF
--- a/src/commands/server.ts
+++ b/src/commands/server.ts
@@ -1,4 +1,5 @@
 import { command, number } from '@drizzle-team/brocli'
+import { stopStatsInterval } from '../server/routes/status.ts'
 import { startServer } from '../server/server.ts'
 
 export const serverCommand = command({
@@ -16,6 +17,10 @@ export const serverCommand = command({
 			// Handle graceful shutdown
 			const gracefulShutdown = (exitCode = 0) => {
 				console.log('\n⚡ Shutting down server gracefully...')
+
+				// Stop the stats interval to prevent keeping the process alive
+				stopStatsInterval()
+
 				server.close(() => {
 					console.log('✅ Server closed successfully')
 					process.exit(exitCode)

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,20 +5,22 @@ import 'dotenv/config'
 import { serverCommand } from './commands/server.ts'
 import { tuiCommand } from './commands/tui.ts'
 
-// Signal handlers for graceful shutdown
-process.on('SIGINT', () => {
-	console.log('\nReceived SIGINT. Gracefully shutting down...')
-	process.exit(0)
-})
+;(async () => {
+	// Signal handlers for graceful shutdown
+	process.on('SIGINT', () => {
+		console.log('\nReceived SIGINT. Gracefully shutting down...')
+		process.exit(0)
+	})
 
-process.on('SIGTERM', () => {
-	console.log('\nReceived SIGTERM. Gracefully shutting down...')
-	process.exit(0)
-})
+	process.on('SIGTERM', () => {
+		console.log('\nReceived SIGTERM. Gracefully shutting down...')
+		process.exit(0)
+	})
 
-// Run the CLI
-run([serverCommand, tuiCommand], {
-	name: 'whap',
-	description: 'WhatsApp Mock Server Development Tool',
-	version: '1.0.0',
-})
+	// Run the CLI
+	await run([serverCommand, tuiCommand], {
+		name: 'whap',
+		description: 'WhatsApp Mock Server Development Tool',
+		version: '1.0.0',
+	})
+})()

--- a/src/server/routes/status.ts
+++ b/src/server/routes/status.ts
@@ -40,22 +40,33 @@ function calculateStats() {
 }
 
 // Store the interval ID for cleanup
-const statsIntervalId: NodeJS.Timeout = setInterval(() => {
-	const stats = calculateStats()
-	broadcast({
-		type: 'STATS_UPDATE',
-		payload: {
-			totalMessages: stats.totalMessages,
-			uptime: stats.uptime,
-			lastActivity: stats.lastActivity,
-		},
-	})
-}, 10000) // Broadcast every 10 seconds
+let statsIntervalId: NodeJS.Timeout | null = null
+
+// Function to start the stats broadcasting interval
+function startStatsInterval() {
+	// Prevent multiple intervals from being created
+	if (statsIntervalId) {
+		return
+	}
+
+	statsIntervalId = setInterval(() => {
+		const stats = calculateStats()
+		broadcast({
+			type: 'STATS_UPDATE',
+			payload: {
+				totalMessages: stats.totalMessages,
+				uptime: stats.uptime,
+				lastActivity: stats.lastActivity,
+			},
+		})
+	}, 10000) // Broadcast every 10 seconds
+}
 
 // Cleanup function to clear the interval
-function cleanupStatsInterval() {
+function stopStatsInterval() {
 	if (statsIntervalId) {
 		clearInterval(statsIntervalId)
+		statsIntervalId = null
 	}
 }
 
@@ -98,4 +109,4 @@ statusRouter.get('/stats', (c) => {
 	}
 })
 
-export { statusRouter, cleanupStatsInterval }
+export { statusRouter, startStatsInterval, stopStatsInterval }

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,7 +7,11 @@ import { logger } from 'hono/logger'
 import { getWebhookConfig } from './config.ts'
 import { conversationRouter } from './routes/conversation.ts'
 import { messagesRouter } from './routes/messages.ts'
-import { statusRouter } from './routes/status.ts'
+import {
+	startStatsInterval,
+	statusRouter,
+	stopStatsInterval,
+} from './routes/status.ts'
 import { templatesRouter } from './routes/templates.ts'
 import { webhooksRouter } from './routes/webhooks.ts'
 import { templateStore } from './store/template-store.ts'
@@ -174,6 +178,9 @@ export async function startServer(port = 3010) {
 	})
 
 	injectWebSocket(server)
+
+	// Start the stats broadcasting interval
+	startStatsInterval()
 
 	console.log(`🚀 Server is running on port ${port}`)
 	console.log(`Websocket server is running on ws://localhost:${port}/ws`)


### PR DESCRIPTION
## Summary

This PR fixes an issue where the CLI was not closing immediately after displaying help or completing certain operations. The root causes were:

1. **Missing await in main execution**: The `run()` function from Brocli was called without `await`, causing the process to continue running even after command completion
2. **Background interval keeping process alive**: A `setInterval` in the status routes was running at module import time, preventing the Node.js event loop from closing

## Changes Made

- **src/index.ts**: Wrapped main execution in async IIFE with proper `await` for Brocli's `run()` function
- **src/server/routes/status.ts**: Moved stats interval from module-level import to `startStatsInterval()` function that only runs when server starts
- **src/server/server.ts**: Added call to `startStatsInterval()` when server starts to maintain functionality
- **src/commands/server.ts**: Added `stopStatsInterval()` call in graceful shutdown to clean up resources

## Test Plan

✅ **Before fix**: Run `bun whap --help` - CLI would not exit immediately, requiring Ctrl+C  
✅ **After fix**: Run `bun whap --help` - CLI displays help and exits immediately  
✅ **Server functionality**: Run `bun whap server` - Server starts normally and stats broadcasting works  
✅ **Server shutdown**: Ctrl+C on running server - Gracefully shuts down with proper cleanup  

To verify the fix:
1. Run `bun whap --help` - should display help and exit immediately 
2. Run `bun whap server --help` - should display server help and exit immediately
3. Run `bun whap server` - should start server normally with stats functionality
4. Press Ctrl+C while server is running - should shutdown gracefully

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* Bug Fixes
  * Prevents the server from hanging after shutdown by ensuring background status updates stop cleanly.
  * Preserves and stabilizes shutdown behavior for termination signals.

* Refactor
  * Shifted startup to an asynchronous flow for clearer lifecycle control.
  * Defers periodic status broadcasting until the server is fully started.
  * Centralizes start/stop management of background tasks to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->