### PR TITLE
feat: add Facebook Graph API phone number info endpoint

### DIFF
--- a/schema/whap-config.schema.json
+++ b/schema/whap-config.schema.json
@@ -14,6 +14,21 @@
 			},
 			"uniqueItems": true,
 			"minItems": 1
+		},
+		"phoneNumbers": {
+			"type": "object",
+			"description": "Map of phone number IDs to their display information",
+			"additionalProperties": {
+				"type": "object",
+				"properties": {
+					"displayPhoneNumber": {
+						"type": "string",
+						"description": "The display phone number for this phone number ID"
+					}
+				},
+				"required": ["displayPhoneNumber"],
+				"additionalProperties": false
+			}
 		}
 	},
 	"additionalProperties": false

--- a/src/server/configuration.ts
+++ b/src/server/configuration.ts
@@ -6,6 +6,11 @@ export interface WhapConfiguration {
 	templates?: {
 		cmd: string
 	}
+	phoneNumbers?: {
+		[phoneNumberId: string]: {
+			displayPhoneNumber: string
+		}
+	}
 }
 
 export interface ParsedWebhookMapping {
@@ -161,4 +166,15 @@ export function getWebhookMappingsFromConfig(): {
 export function getTemplatesConfig(): { cmd: string } | null {
 	const config = loadConfigFile()
 	return config?.templates ?? null
+}
+
+/**
+ * Get phone numbers configuration from configuration file
+ * @returns Phone numbers configuration or null if not present
+ */
+export function getPhoneNumbersConfig():
+	| WhapConfiguration['phoneNumbers']
+	| null {
+	const config = loadConfigFile()
+	return config?.phoneNumbers ?? null
 }

--- a/src/server/routes/phone.ts
+++ b/src/server/routes/phone.ts
@@ -1,0 +1,30 @@
+import { Hono } from 'hono'
+import { getPhoneNumbersConfig } from '../configuration.ts'
+
+export const phoneRouter = new Hono()
+
+phoneRouter.get('/:phoneNumberId', (c) => {
+	const phoneNumberId = c.req.param('phoneNumberId')
+	const phoneNumbersConfig = getPhoneNumbersConfig()
+
+	if (!phoneNumbersConfig || !phoneNumbersConfig[phoneNumberId]) {
+		console.warn(
+			`Phone number ID '${phoneNumberId}' not found in configuration. Please add it to whap.json under 'phoneNumbers'.`
+		)
+		return c.json(
+			{
+				error: {
+					message: `Phone number ID '${phoneNumberId}' not configured`,
+					type: 'phone_number_not_found',
+					code: 500,
+				},
+			},
+			500
+		)
+	}
+
+	const phoneInfo = phoneNumbersConfig[phoneNumberId]
+	return c.json({
+		display_phone_number: phoneInfo.displayPhoneNumber,
+	})
+})

--- a/src/server/server.ts
+++ b/src/server/server.ts
@@ -7,13 +7,10 @@ import { logger } from 'hono/logger'
 import { getWebhookConfig } from './config.ts'
 import { getTemplatesConfig } from './configuration.ts'
 import { conversationRouter } from './routes/conversation.ts'
-import { createMessagesRouter, messagesRouter } from './routes/messages.ts'
-import {
-	startStatsInterval,
-	statusRouter,
-	stopStatsInterval,
-} from './routes/status.ts'
-import { createTemplatesRouter, templatesRouter } from './routes/templates.ts'
+import { createMessagesRouter } from './routes/messages.ts'
+import { phoneRouter } from './routes/phone.ts'
+import { startStatsInterval, statusRouter } from './routes/status.ts'
+import { createTemplatesRouter } from './routes/templates.ts'
 import { webhooksRouter } from './routes/webhooks.ts'
 import { TemplateStore } from './store/template-store.ts'
 import { TemplateResolver } from './template-resolver.ts'
@@ -105,9 +102,11 @@ function createApp(templateStore: TemplateStore) {
 
 	app.route('/v22.0', messagesRouter)
 	app.route('/v22.0', templatesRouter)
+	app.route('/v22.0', phoneRouter)
 	// Assuming 22 and 23 are the same
 	app.route('/v23.0', messagesRouter)
 	app.route('/v23.0', templatesRouter)
+	app.route('/v23.0', phoneRouter)
 	// The /mock path is for internal simulation tools
 	app.route('/mock', webhooksRouter)
 	app.route('/status', statusRouter)

--- a/test-whap.json
+++ b/test-whap.json
@@ -1,0 +1,10 @@
+{
+	"phoneNumbers": {
+		"123456789": {
+			"displayPhoneNumber": "1234567890"
+		},
+		"987654321": {
+			"displayPhoneNumber": "9876543210"
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- Added new `/v23.0/<phone_number_id>` endpoint that returns phone number display information
- Supports optional configuration via `phoneNumbers` field in whap.json
- Returns 500 error with console.warn when phone number ID is not configured
- Successfully tested the implementation

## Changes
- Added `phoneNumbers` configuration field to whap.json schema
- Created phone router with GET endpoint for phone number info
- Integrated phone router into both v22.0 and v23.0 API versions
- Added configuration loading function for phone numbers
- Included test configuration file for validation

## Test plan
- ✅ Verified endpoint responds correctly with configured phone numbers
- ✅ Confirmed error handling for unconfigured phone number IDs
- ✅ Tested schema validation for whap.json configuration
- ✅ Validated integration with both API versions

🤖 Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added configurable phone numbers mapping (ID -> display number).
  - New API endpoint to fetch a phone number’s display value by ID, with clear error response if not found. Available in API v22.0 and v23.0.
- Refactor
  - Streamlined router creation and mounting to improve maintainability; no functional changes expected.
- Tests/Chores
  - Added sample phone numbers configuration to test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->