### PR TITLE
Fix missing import and harden release pipeline with type-check step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Install dependencies
         run: bun install
 
+      - name: Compile TypeScript
+        run: bun tsc --noEmit
+
       - name: Build macOS binary
         run: bun build src/index.ts --compile --outfile whap --target=bun-darwin-x64
 
@@ -68,10 +71,10 @@ jobs:
         run: |
           VERSION="${{ steps.version.outputs.version }}"
           SHA256="${{ steps.checksum.outputs.sha256 }}"
-          
+
           # Create Formula directory if it doesn't exist
           mkdir -p homebrew-tap/Formula
-          
+
           # Create or update the formula
           cat > homebrew-tap/Formula/whap.rb << EOF
           class Whap < Formula
@@ -81,11 +84,11 @@ jobs:
             url "https://github.com/fdarian/whap/releases/download/v$VERSION/whap-darwin-x64.tar.gz"
             sha256 "$SHA256"
             license "MIT"
-          
+
             def install
               bin.install "whap"
             end
-          
+
             test do
               system "#{bin}/whap", "--version"
             end

--- a/src/server/routes/webhooks.ts
+++ b/src/server/routes/webhooks.ts
@@ -4,6 +4,7 @@ import { getAllWebhookMappings, getWebhookUrl } from '../config.ts'
 import { getWebhookSecret } from '../configuration.ts'
 import {
 	computeHmacSignatureHeader,
+	serializeJsonWithEscapedUnicode,
 	SIGNATURE_HEADER,
 } from '../middleware/hmac-signature.ts'
 import { mockStore } from '../store/memory-store.ts'


### PR DESCRIPTION
Hello @fdarian it's me, again. I have a very important fix of an issue that went through the last PR.

## Summary

- serializeJsonWithEscapedUnicode was being called in webhooks.ts without being imported, which would cause a runtime failure when delivering webhooks
- the release pipeline now runs a TypeScript type-check before building to catch issues like this before they reach a release.

##  Changes

`src/server/routes/webhooks.ts`

 - Added the missing import for serializeJsonWithEscapedUnicode from hmac-signature.ts. The function was already in use at call-site (line 324) but absent from the import block, meaning any webhook delivery attempt would blow up at runtime.
  
`.github/workflows/release.yml`

- Added bun tsc --noEmit before the build step so the release pipeline fails fast on type errors — catching missing imports like the one above before a binary is ever compiled and published.
- Removed trailing whitespace and added a missing newline at EOF in the Homebrew formula generation block.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow with TypeScript compilation verification step.
  * Updated webhook route imports for code organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/fdarian/whap/pull/16?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->